### PR TITLE
F3N-178 ES Store release action

### DIFF
--- a/.github/workflows/Stores-EventStore-Release.yml
+++ b/.github/workflows/Stores-EventStore-Release.yml
@@ -1,0 +1,35 @@
+# This will build a release version of Troolio.Stores.EventStore and publish the nuget package
+name: Troolio_EventStore_Release
+
+# Controls when the workflow will run
+on:
+    push:
+        tags: 
+            - 'Troolio.Stores.EventStore_[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+    build-and-push:
+        runs-on: ubuntu-latest
+        steps:
+        # checkout the repo
+        - name: 'Checkout GitHub Action'
+          uses: actions/checkout@main
+
+        - name: Install dependencies
+          run: dotnet restore Stores/Troolio.Stores.EventStore/Troolio.Stores.EventStore.csproj
+      
+        - name: Build
+          run: dotnet build --configuration Release --no-restore Stores/Troolio.Stores.EventStore/Troolio.Stores.EventStore.csproj
+
+        - name: Parser
+          uses: johngeorgewright/parse-version-action@v1.0.2
+          id: parser
+          with:
+            ref: ${{ github.ref }}
+            trim-start: Troolio.Stores.EventStore_
+
+        - name: Create NuGet Package
+          run: dotnet pack --configuration Release Stores/Troolio.Stores.EventStore/Troolio.Stores.EventStore.csproj --no-build -p:PackageVersion=${{ steps.parser.outputs.version }}
+
+        - name: Publish the package to nuget
+          run: dotnet nuget push Stores/Troolio.Stores.EventStore/*/**/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{secrets.NUGET_API_KEY}} --skip-duplicate

--- a/Stores/Troolio.Stores.EventStore/Troolio.Stores.EventStore.csproj
+++ b/Stores/Troolio.Stores.EventStore/Troolio.Stores.EventStore.csproj
@@ -10,13 +10,14 @@
     <PackageProjectUrl>https://github.com/Fifty3North/troolio</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Fifty3North/troolio.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="EventStore.Client" Version="21.2.2" />
     <PackageReference Include="EventStore.Client.Grpc.Streams" Version="21.2.0" />
     <PackageReference Include="Microsoft.Orleans.Runtime.Abstractions" Version="3.6.4" />
-    <PackageReference Include="Troolio.Core" Version="1.0.3.112-prerelease" />
+    <PackageReference Include="Troolio.Core" Version="1.0.3" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Will need an action secret added for NUGET_API_KEY to give permission to publish to nuget.org. Once in place it is triggered by tagging the repo with Troolio.Stores.EventStore_[0-9]+.[0-9]+.[0-9]+